### PR TITLE
Allow changing infiniteScrollDisabled

### DIFF
--- a/src/modules/infinite-scroll.directive.ts
+++ b/src/modules/infinite-scroll.directive.ts
@@ -43,8 +43,8 @@ export class InfiniteScrollDirective
     this.setup();
   }
 
-  ngOnChanges({ infiniteScrollContainer }: SimpleChanges) {
-    if (inputPropChanged(infiniteScrollContainer)) {
+  ngOnChanges({ infiniteScrollContainer, infiniteScrollDisabled }: SimpleChanges) {
+    if (inputPropChanged(infiniteScrollContainer) || inputPropChanged(infiniteScrollDisabled)) {
       this.destroyScroller();
       this.setup();
     }


### PR DESCRIPTION
If infiniteScrollDisabled is changed, call setup() again to recreate the scroller.